### PR TITLE
Found a typo

### DIFF
--- a/getting-started/using-the-cli.md
+++ b/getting-started/using-the-cli.md
@@ -49,7 +49,7 @@ my-app
 
 ## Installing dependencies
 
-You can install dependencies for an application by invoking the binary with the `intall` command:
+You can install dependencies for an application by invoking the binary with the `install` command:
 
 ```text
 mint install


### PR DESCRIPTION
's' was missing from the 'install' command.