### PR TITLE
Update store.md

### DIFF
--- a/reference/store.md
+++ b/reference/store.md
@@ -30,5 +30,5 @@ States on a store define keys which correspond to specific type of values. They 
 
 ## Connecting to components
 
-Stores can be connected to components. To learn more, check out [ components](components/connecting-stores.md).
+Stores can be connected to components. To learn more, check out [components](components/connecting-stores.md).
 


### PR DESCRIPTION
super-trivial (removed extraneous space before 'components' link on line 33 (was showing a space with a link underscore between "check out" and "components")